### PR TITLE
feat: add public root endpoint and health controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ target/
 # OS files
 .DS_Store
 Thumbs.db
+
+.vscode/

--- a/src/main/java/com/aj/travel/common/config/SecurityConfig.java
+++ b/src/main/java/com/aj/travel/common/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(new AntPathRequestMatcher("/")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/auth/register", HttpMethod.POST.name())).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/auth/login", HttpMethod.POST.name())).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/admin/register", HttpMethod.POST.name())).permitAll()

--- a/src/main/java/com/aj/travel/common/controller/HealthController.java
+++ b/src/main/java/com/aj/travel/common/controller/HealthController.java
@@ -1,0 +1,13 @@
+package com.aj.travel.common.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+
+    @GetMapping("/")
+    public String health() {
+        return "Tours & Travel API is running";
+    }
+}

--- a/src/test/java/com/aj/travel/common/controller/HealthControllerTest.java
+++ b/src/test/java/com/aj/travel/common/controller/HealthControllerTest.java
@@ -1,0 +1,50 @@
+package com.aj.travel.common.controller;
+
+import com.aj.travel.common.config.SecurityConfig;
+import com.aj.travel.common.security.CustomUserDetailsService;
+import com.aj.travel.common.security.JwtAuthenticationFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(HealthController.class)
+@Import(SecurityConfig.class)
+class HealthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        doAnswer(invocation -> {
+            jakarta.servlet.FilterChain filterChain = invocation.getArgument(2);
+            jakarta.servlet.ServletRequest request = invocation.getArgument(0);
+            jakarta.servlet.ServletResponse response = invocation.getArgument(1);
+            filterChain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    void rootEndpoint_isPublicAndReturnsStatusMessage() throws Exception {
+        mockMvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Tours & Travel API is running"));
+    }
+}


### PR DESCRIPTION
### Summary

Adds a public root endpoint (`/`) to verify API availability and removes the 401 Unauthorized response when accessing the base URL.

### Changes

* Updated `SecurityConfig` to allow public access to `/`
* Added `HealthController` with a root endpoint returning API status
* Ensures the backend service health can be verified without authentication

### Endpoint Added

GET /

Response:
Tours & Travel API is running

### Reason

Previously, accessing the root URL returned a `401 Unauthorized` error because all routes required authentication. This change allows public health verification of the deployed backend.

### Impact

* No changes to authentication or JWT logic
* All protected APIs remain secured
* Improves API visibility for deployment checks and Swagger access
