### PR TITLE
ci: fix workflows and separate backend CI and docker build pipelines

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -28,8 +28,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
 
       - name: Make Maven wrapper executable
         run: chmod +x mvnw

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,10 +8,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: docker-build-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   docker:
     name: Build and Push Docker Image


### PR DESCRIPTION
### Summary

Fix GitHub Actions workflow configuration by separating CI and Docker build pipelines into two independent workflow files.

### Changes

* Created `backend-ci.yml` to run Maven build and tests on `dev` and `architecture-rebuild` branches.
* Created `docker-build.yml` to build and push the Docker image when changes are merged into `main`.
* Fixed YAML structure issue where two workflows were previously combined in a single file.

### CI/CD Pipeline Flow

feature branch → dev → main

1. Push to **dev**

   * Backend CI workflow runs
   * Executes `mvn clean verify`

2. Merge **dev → main**

   * Docker workflow runs
   * Builds Docker image
   * Pushes image to Docker Hub

3. Render pulls the latest Docker image and deploys the backend service.

### Impact

* Restores correct CI/CD pipeline behavior
* Ensures Docker images are automatically built and pushed on production releases
* Keeps backend tests running on development branches
