### PR TITLE
feat: add JSON root endpoint for API info

### DIFF
--- a/src/main/java/com/aj/travel/common/controller/HealthController.java
+++ b/src/main/java/com/aj/travel/common/controller/HealthController.java
@@ -3,11 +3,17 @@ package com.aj.travel.common.controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 @RestController
 public class HealthController {
 
     @GetMapping("/")
-    public String health() {
-        return "Tours & Travel API is running";
+    public Map<String, String> apiInfo() {
+        return Map.of(
+                "health", "/api/system/health",
+                "message", "Tours & Travel Backend API is running",
+                "swagger", "/swagger-ui/index.html"
+        );
     }
 }


### PR DESCRIPTION
### Summary

Add a JSON response for the root endpoint (`/`) so the API returns structured system information instead of plain text.

### Changes

* Updated `HealthController` root endpoint
* Root endpoint now returns structured JSON
* Provides links to health endpoint and Swagger documentation

### New Root Response

GET /

```json
{
  "health": "/api/system/health",
  "message": "Tours & Travel Backend API is running",
  "swagger": "/swagger-ui/index.html"
}
```

### Purpose

This improves API discoverability and provides quick system status information for developers and monitoring tools.
