### PR TITLE
Add Spring profile configuration for Docker deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       redis:
         condition: service_healthy
     environment:
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE}
       SERVER_PORT: 8080
       DB_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB}
       DB_USERNAME: ${POSTGRES_USER}


### PR DESCRIPTION
## Summary

* Added `SPRING_PROFILES_ACTIVE` environment variable to Docker Compose backend service.
* Enabled profile selection through environment configuration.
* Ensures production deployments load `application-prod.yml`.
* Keeps local development using `application-dev.yml`.

## Impact

* Local environment remains unchanged.
* AWS Docker deployments can now run with the `prod` profile.
